### PR TITLE
B/feature/#16

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -44,7 +44,12 @@ class Event < ActiveRecord::Base
   validates_numericality_of :participant_count, only_integer: true, greater_than_or_equal_to: 0
   validate :dates_cannot_be_in_the_past,:start_before_end_date
 
-  after_save :set_status_to_pending_and_destroy_suggestion, :if => Proc.new {|event| event.event_suggestion  and event.event_suggestion.status == 'rejected_suggestion' and event.status = 'declined'}
+  after_save do
+    check_group 
+    if self.event_suggestion  and self.event_suggestion.status == 'rejected_suggestion' and self.status = 'declined'
+      set_status_to_pending_and_destroy_suggestion
+    end
+  end
   # Scope definitions. We implement all Filterrific filters through ActiveRecord
   # scopes. In this example we omit the implementation of the scopes for brevity.
   # Please see 'Scope patterns' for scope implementation details.
@@ -132,6 +137,23 @@ class Event < ActiveRecord::Base
 
   def set_status_to_pending_and_destroy_suggestion
     self.event_suggestion.destroy
+    # WEGEN FEHLERHAFTER VERSION IM DEV KAM IMMER ZUM RAUM UND EIN LEERER RAUM ZURÜCK 
+    # SOLLTE DAS GEFIXT WERDEN KANN ES SEIN, DASS DAS HIER FEHLER WIRFT UND GEFIXT WERDEN MUSS
+    # if params['room_ids'].count == 2  muss auf 1 geändert werden
+    # DON'T BLAME ME 
+    # @OLEGSFINEST
     self.update_columns(:status => 'pending')
+  end
+
+  def check_group
+    only_group_rooms = true
+    self.rooms.each do |room|
+      if not room.group_id or not User.find(self.user_id).is_member_of_group(room.group_id)
+        only_group_rooms = false
+      end
+    end
+    if only_group_rooms
+      self.update_columns(:status => 'approved')
+    end
   end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe EventsController, :type => :controller do
   }
   let(:task) { create :task }
   let(:user) { create :user }
+  let(:member) {create :groupMember}
+  let(:room) {create :groupRoom}
+
 
   let(:valid_attributes) {
     {name:'Michas GB',
@@ -39,7 +42,35 @@ RSpec.describe EventsController, :type => :controller do
     user_id: user.id
     }
   }
- 
+
+  let(:valid_attributes_with_room) {
+    {name:'Das Bo live',
+    description:'Türlich Türlich',
+    participant_count: 2000,
+    starts_at_date: (Time.now).strftime("%Y-%m-%d"),
+    ends_at_date: (Time.now + 7200).strftime("%Y-%m-%d"),    # + 2h
+    starts_at_time: (Time.now).strftime("%H:%M:%S"),
+    ends_at_time: (Time.now + 7200).strftime("%H:%M:%S"),
+    is_private: true,
+    user_id: user.id,
+    room_ids: ['1337']
+    }
+  }
+  
+  let(:valid_attributes_with_two_rooms) {
+    {name:'Das Bo live',
+    description:'Türlich Türlich',
+    participant_count: 2000,
+    starts_at_date: (Time.now).strftime("%Y-%m-%d"),
+    ends_at_date: (Time.now + 7200).strftime("%Y-%m-%d"),    # + 2h
+    starts_at_time: (Time.now).strftime("%H:%M:%S"),
+    ends_at_time: (Time.now + 7200).strftime("%H:%M:%S"),
+    is_private: true,
+    user_id: user.id,
+    rooms: ["1","1337"]
+    }
+  }
+
  let(:valid_attributes_for_request) {
     {name:'Michas GB',
     description:'Coole Sache',
@@ -169,6 +200,7 @@ RSpec.describe EventsController, :type => :controller do
 
   before(:each) do
     @request.env["devise.mapping"] = Devise.mappings[:user]
+    room.update_attribute(:id,1337)
     sign_in user
   end
 
@@ -368,6 +400,26 @@ RSpec.describe EventsController, :type => :controller do
       it "re-renders the 'new' template" do
         post :create, {:event => invalid_participant_count_for_request}, valid_session
         expect(response).to render_template("new")
+      end
+    end
+    describe "for an event with only rooms of groups the user belongs to" do
+      it"directly approves the event" do
+        sign_in member
+        post :create, {:event => valid_attributes_with_room}, valid_session
+        expect(assigns(:event).status).to eq("approved")
+      end
+    end
+    describe "for an event with rooms of which at least one does NOT belong to a group the user belongs to" do
+      it"creates an event with status pending" do
+        post :create, {:event => valid_attributes_for_request}, valid_session
+        expect(assigns(:event).status).to eq("pending")
+      end
+    end
+    describe "for an event with rooms of 1) groups the user belongs to and 2) another room" do
+      it"creates an event with status pending" do
+        sign_in member
+        post :create, {:event => valid_attributes_with_two_rooms}, valid_session
+        expect(assigns(:event).status).to eq("pending")
       end
     end
 

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -423,6 +423,27 @@ RSpec.describe GroupsController, :type => :controller do
           expect(response).to redirect_to(manage_rooms_group_path(group1))
         end
       end
+
+      describe "unassigning a room" do
+        context "that is already assigned" do
+          it "does unassign a room (as admin)", :isAdmin => true do
+            get :unassign_room, {:id => group2.to_param, :room_id => room1.to_param}
+            expect(room1.reload.group).to eq (nil)
+          end
+          it "does not unassign a room (as normal user)", :isAdmin => false do
+            get :unassign_room, {:id => group2.to_param, :room_id => room1.to_param}
+            expect(room1.reload.group).to eq (group2)
+          end
+        end
+        it "redirects to the start page when not authorized", :isAdmin => false do
+          get :unassign_room, {:id => group2.to_param, :room_id => room1.to_param}
+          expect(response).to redirect_to(root_path)
+        end
+        it "redirects to the manage_rooms page when authorized", :isAdmin => true do
+          get :unassign_room, {:id => group2.to_param, :room_id => room1.to_param}
+          expect(response).to redirect_to(manage_rooms_group_path(group2))
+        end
+      end
     end
   end
 end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -3,5 +3,8 @@
 FactoryGirl.define do
   factory :group do
     sequence(:name) { |n| "AGroup#{n}" }
+     factory :group_with_room do |g|
+		g.id 55
+  	end
   end
 end

--- a/spec/factories/rooms.rb
+++ b/spec/factories/rooms.rb
@@ -3,6 +3,9 @@ FactoryGirl.define do
     f.name "Room"
     f.size 1
     equipment []
+    factory :groupRoom do |g|
+      g.group_id 55
+    end
   end	
   
   factory :room1, parent: :room do |f|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,6 +15,15 @@ FactoryGirl.define do
     	end
   	end
 
+    factory :groupMember do
+      after :create do |member|
+        member.sign_in_count = 1337
+        member.groups << FactoryGirl.create(:group_with_room)
+        member.save
+        member.reload
+      end
+    end
+
     sequence(:username) { |n| "test.user#{n}" }
     sequence(:email) { |n| "test.user#{n}@example.com" }
   end


### PR DESCRIPTION
- Group members can create events for their group rooms, without needing approval + testing
- Room Assignment and unassignment tests (has already been implemented, becaus this part of the user story was doable from sprint 1)