### PR TITLE
Fixed Event Show View. Now hiding all for non-involved users. Ref #121

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -78,6 +78,7 @@
   <%= render(partial: '/tasks/tasks_box', locals: { tasks: @tasks, event: @event })%> 
 </div>
 
+<% unless @feed_entries.nil? %>
 <div class="event-view-section">
   <h3><%= t 'activities.activity_log' %></h3>
 
@@ -99,6 +100,7 @@
     <% end %>  
   </div>
 </div>
+<% end %>
 
 <div class="row">
   <div class="col-xs-4 col-md-3">


### PR DESCRIPTION
Fix event show view by checking if activity feed is available, ref #121 