### PR TITLE
Fix activity log entry creation

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -194,7 +194,7 @@ class EventsController < GenericEventsController
     @event.attributes = filtered_params
     changed_attributes = @event.changed
     @update_result = @event.update(filtered_params)
-    if @update_result
+    if @update_result && changed_attributes.any?
       @event.activities << Activity.create(:username => current_user.username,
                                           :action => params[:action], :controller => params[:controller],
                                           :changed_fields => changed_attributes)

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -912,6 +912,14 @@ RSpec.describe EventsController, :type => :controller do
         }.to change(activities, :count).by(0)
       end
 
+      it "creates no activity when no fields are updated" do
+        event = Event.create! valid_attributes
+        activities = event.activities
+        expect{
+        put :update, {:id => event.to_param, :event => valid_attributes}, valid_session
+        }.to change(activities, :count).by(0)
+      end
+
       it "changes the specified schedule" do
         weekly_recurring_event = FactoryGirl.create(:weekly_recurring_event, :user_id => user.id)
         put :update, {:id => weekly_recurring_event.to_param, :event => valid_attributes_weekly_recurring_event}


### PR DESCRIPTION
An activity log entry was created everytime the updated succeeded without any changed fields ref #353